### PR TITLE
feat: code generate mutations

### DIFF
--- a/internal/codegen/tablecodegen/interleavedreadtransaction_test.go
+++ b/internal/codegen/tablecodegen/interleavedreadtransaction_test.go
@@ -24,6 +24,9 @@ func TestInterleavedReadTransaction_GenerateCode(t *testing.T) {
 					Table:             table,
 					InterleavedTables: interleavedTables,
 				}.GenerateCode(f)
+				for _, interleavedTable := range interleavedTables {
+					PartialKeyCodeGenerator{Table: interleavedTable}.GenerateCode(f)
+				}
 			}
 			RowCodeGenerator{Table: table}.GenerateCode(f)
 			PrimaryKeyCodeGenerator{Table: table}.GenerateCode(f)

--- a/internal/codegen/tablecodegen/interleavedrow_test.go
+++ b/internal/codegen/tablecodegen/interleavedrow_test.go
@@ -16,6 +16,9 @@ func TestInterleavedRowCodeGenerator_GenerateCode(t *testing.T) {
 					Table:             table,
 					InterleavedTables: interleavedTables,
 				}.GenerateCode(f)
+				for _, interleavedTable := range interleavedTables {
+					PartialKeyCodeGenerator{Table: interleavedTable}.GenerateCode(f)
+				}
 			}
 			RowCodeGenerator{Table: table}.GenerateCode(f)
 			PrimaryKeyCodeGenerator{Table: table}.GenerateCode(f)

--- a/internal/codegen/tablecodegen/interleavedrowiterator_test.go
+++ b/internal/codegen/tablecodegen/interleavedrowiterator_test.go
@@ -20,6 +20,9 @@ func TestInterleavedRowIteratorCodeGenerator_GenerateCode(t *testing.T) {
 					Table:             table,
 					InterleavedTables: interleavedTables,
 				}.GenerateCode(f)
+				for _, interleavedTable := range interleavedTables {
+					PartialKeyCodeGenerator{Table: interleavedTable}.GenerateCode(f)
+				}
 			}
 			RowCodeGenerator{Table: table}.GenerateCode(f)
 			PrimaryKeyCodeGenerator{Table: table}.GenerateCode(f)

--- a/internal/codegen/tablecodegen/partialkey.go
+++ b/internal/codegen/tablecodegen/partialkey.go
@@ -36,12 +36,13 @@ func (g PartialKeyCodeGenerator) GenerateCode(f *codegen.File) {
 		f.P("Valid", g.FieldName(keyPart), " bool")
 	}
 	f.P("}")
-	g.generateSpannerKeyFunction(f)
-	g.generateBoolExprFunction(f)
-	g.generateQualifiedBoolExprFunction(f)
+	g.generateSpannerKeyMethod(f)
+	g.generateDeleteMethod(f)
+	g.generateBoolExprMethod(f)
+	g.generateQualifiedBoolExprMethod(f)
 }
 
-func (g PartialKeyCodeGenerator) generateSpannerKeyFunction(f *codegen.File) {
+func (g PartialKeyCodeGenerator) generateSpannerKeyMethod(f *codegen.File) {
 	spannerPkg := f.Import("cloud.google.com/go/spanner")
 	f.P()
 	f.P("func (k ", g.Type(), ") SpannerKey() ", spannerPkg, ".Key {")
@@ -75,7 +76,15 @@ func (g PartialKeyCodeGenerator) generateSpannerKeyFunction(f *codegen.File) {
 	f.P("}")
 }
 
-func (g PartialKeyCodeGenerator) generateBoolExprFunction(f *codegen.File) {
+func (g PartialKeyCodeGenerator) generateDeleteMethod(f *codegen.File) {
+	spannerPkg := f.Import("cloud.google.com/go/spanner")
+	f.P()
+	f.P("func (k ", g.Type(), ") Delete() *", spannerPkg, ".Mutation {")
+	f.P("return ", spannerPkg, ".Delete(", strconv.Quote(string(g.Table.Name)), ", k.SpannerKey())")
+	f.P("}")
+}
+
+func (g PartialKeyCodeGenerator) generateBoolExprMethod(f *codegen.File) {
 	spansqlPkg := f.Import("cloud.google.com/go/spanner/spansql")
 	f.P()
 	k0 := g.Table.PrimaryKey[0]
@@ -110,7 +119,7 @@ func (g PartialKeyCodeGenerator) generateBoolExprFunction(f *codegen.File) {
 	f.P("}")
 }
 
-func (g PartialKeyCodeGenerator) generateQualifiedBoolExprFunction(f *codegen.File) {
+func (g PartialKeyCodeGenerator) generateQualifiedBoolExprMethod(f *codegen.File) {
 	spansqlPkg := f.Import("cloud.google.com/go/spanner/spansql")
 	f.P()
 	k0 := g.Table.PrimaryKey[0]

--- a/internal/codegen/tablecodegen/primarykey.go
+++ b/internal/codegen/tablecodegen/primarykey.go
@@ -44,11 +44,20 @@ func (g PrimaryKeyCodeGenerator) GenerateCode(f *codegen.File) {
 	f.P("func (k ", g.Type(), ") SpannerKeySet() ", spannerPkg, ".KeySet {")
 	f.P("return k.SpannerKey()")
 	f.P("}")
-	g.generateBoolExprFunction(f)
-	g.generateQualifiedBoolExprFunction(f)
+	g.generateDeleteMethod(f)
+	g.generateBoolExprMethod(f)
+	g.generateQualifiedBoolExprMethod(f)
 }
 
-func (g PrimaryKeyCodeGenerator) generateBoolExprFunction(f *codegen.File) {
+func (g PrimaryKeyCodeGenerator) generateDeleteMethod(f *codegen.File) {
+	spannerPkg := f.Import("cloud.google.com/go/spanner")
+	f.P()
+	f.P("func (k ", g.Type(), ") Delete() *", spannerPkg, ".Mutation {")
+	f.P("return ", spannerPkg, ".Delete(", strconv.Quote(string(g.Table.Name)), ", k.SpannerKey())")
+	f.P("}")
+}
+
+func (g PrimaryKeyCodeGenerator) generateBoolExprMethod(f *codegen.File) {
 	spansqlPkg := f.Import("cloud.google.com/go/spanner/spansql")
 	f.P()
 	k0 := g.Table.PrimaryKey[0]
@@ -79,7 +88,7 @@ func (g PrimaryKeyCodeGenerator) generateBoolExprFunction(f *codegen.File) {
 	f.P("}")
 }
 
-func (g PrimaryKeyCodeGenerator) generateQualifiedBoolExprFunction(f *codegen.File) {
+func (g PrimaryKeyCodeGenerator) generateQualifiedBoolExprMethod(f *codegen.File) {
 	spansqlPkg := f.Import("cloud.google.com/go/spanner/spansql")
 	f.P()
 	k0 := g.Table.PrimaryKey[0]

--- a/internal/codegen/tablecodegen/testdata/1.sql.interleavedreadtransaction.go
+++ b/internal/codegen/tablecodegen/testdata/1.sql.interleavedreadtransaction.go
@@ -82,15 +82,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -115,6 +106,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -133,6 +155,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/1.sql.interleavedrow.go
+++ b/internal/codegen/tablecodegen/testdata/1.sql.interleavedrow.go
@@ -81,15 +81,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -114,6 +105,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -132,6 +154,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/1.sql.interleavedrowiterator.go
+++ b/internal/codegen/tablecodegen/testdata/1.sql.interleavedrowiterator.go
@@ -82,15 +82,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -115,6 +106,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -133,6 +155,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/1.sql.keyrange.go
+++ b/internal/codegen/tablecodegen/testdata/1.sql.keyrange.go
@@ -31,6 +31,10 @@ func (k SingersPartialKey) SpannerKey() spanner.Key {
 	return spanner.Key{k.SingerId}
 }
 
+func (k SingersPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
+}
+
 func (k SingersPartialKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,

--- a/internal/codegen/tablecodegen/testdata/1.sql.partialkey.go
+++ b/internal/codegen/tablecodegen/testdata/1.sql.partialkey.go
@@ -17,6 +17,10 @@ func (k SingersPartialKey) SpannerKey() spanner.Key {
 	return spanner.Key{k.SingerId}
 }
 
+func (k SingersPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
+}
+
 func (k SingersPartialKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,

--- a/internal/codegen/tablecodegen/testdata/1.sql.primarykey.go
+++ b/internal/codegen/tablecodegen/testdata/1.sql.primarykey.go
@@ -23,6 +23,10 @@ func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
 }
 
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
+}
+
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,

--- a/internal/codegen/tablecodegen/testdata/1.sql.readtransaction.go
+++ b/internal/codegen/tablecodegen/testdata/1.sql.readtransaction.go
@@ -207,15 +207,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -240,6 +231,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -258,6 +280,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/1.sql.row.go
+++ b/internal/codegen/tablecodegen/testdata/1.sql.row.go
@@ -81,15 +81,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -114,6 +105,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -132,6 +154,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/2.sql.interleavedrow.go
+++ b/internal/codegen/tablecodegen/testdata/2.sql.interleavedrow.go
@@ -19,8 +19,14 @@ type SingersAndAlbumsRow struct {
 	Albums     []*AlbumsRow       `spanner:"Albums"`
 }
 
-func (r *SingersAndAlbumsRow) PrimaryKey() SingersPrimaryKey {
+func (r *SingersAndAlbumsRow) SingersPrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
+		SingerId: r.SingerId,
+	}
+}
+
+func (r SingersAndAlbumsRow) AlbumsPartialKey() AlbumsPartialKey {
+	return AlbumsPartialKey{
 		SingerId: r.SingerId,
 	}
 }
@@ -53,6 +59,105 @@ func (r *SingersAndAlbumsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 		}
 	}
 	return nil
+}
+
+func (r SingersAndAlbumsRow) SingersRow() *SingersRow {
+	return &SingersRow{
+		SingerId:   r.SingerId,
+		FirstName:  r.FirstName,
+		LastName:   r.LastName,
+		SingerInfo: r.SingerInfo,
+	}
+}
+
+func (r SingersAndAlbumsRow) Insert() []*spanner.Mutation {
+	n := 1
+	n += len(r.Albums)
+	mutations := make([]*spanner.Mutation, 0, n)
+	mutations = append(mutations, r.SingersRow().Insert())
+	for _, interleavedRow := range r.Albums {
+		mutations = append(mutations, interleavedRow.Insert())
+	}
+	return mutations
+}
+
+func (r SingersAndAlbumsRow) Update() []*spanner.Mutation {
+	n := 2 // one delete mutation per interleaved table
+	n += len(r.Albums)
+	mutations := make([]*spanner.Mutation, 0, n)
+	mutations = append(mutations, r.SingersRow().Update())
+	mutations = append(mutations, r.AlbumsPartialKey().Delete())
+	for _, interleavedRow := range r.Albums {
+		mutations = append(mutations, interleavedRow.Insert())
+	}
+	return mutations
+}
+
+type AlbumsPartialKey struct {
+	SingerId     int64
+	AlbumId      int64
+	ValidAlbumId bool
+}
+
+func (k AlbumsPartialKey) SpannerKey() spanner.Key {
+	n := 1
+	if k.ValidAlbumId {
+		n++
+	}
+	result := make(spanner.Key, 0, n)
+	result = append(result, k.SingerId)
+	if k.ValidAlbumId {
+		result = append(result, k.AlbumId)
+	}
+	return result
+}
+
+func (k AlbumsPartialKey) SpannerKeySet() spanner.KeySet {
+	return k.SpannerKey()
+}
+
+func (k AlbumsPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
+}
+
+func (k AlbumsPartialKey) BoolExpr() spansql.BoolExpr {
+	b := spansql.BoolExpr(spansql.ComparisonOp{
+		Op:  spansql.Eq,
+		LHS: spansql.ID("SingerId"),
+		RHS: spansql.IntegerLiteral(k.SingerId),
+	})
+	if k.ValidAlbumId {
+		b = spansql.LogicalOp{
+			Op:  spansql.And,
+			LHS: b,
+			RHS: spansql.ComparisonOp{
+				Op:  spansql.Eq,
+				LHS: spansql.ID("AlbumId"),
+				RHS: spansql.IntegerLiteral(k.AlbumId),
+			},
+		}
+	}
+	return spansql.Paren{Expr: b}
+}
+
+func (k AlbumsPartialKey) QualifiedBoolExpr(prefix spansql.PathExp) spansql.BoolExpr {
+	b := spansql.BoolExpr(spansql.ComparisonOp{
+		Op:  spansql.Eq,
+		LHS: append(prefix, spansql.ID("SingerId")),
+		RHS: spansql.IntegerLiteral(k.SingerId),
+	})
+	if k.ValidAlbumId {
+		b = spansql.LogicalOp{
+			Op:  spansql.And,
+			LHS: b,
+			RHS: spansql.ComparisonOp{
+				Op:  spansql.Eq,
+				LHS: append(prefix, spansql.ID("AlbumId")),
+				RHS: spansql.IntegerLiteral(k.AlbumId),
+			},
+		}
+	}
+	return spansql.Paren{Expr: b}
 }
 
 type SingersRow struct {
@@ -125,15 +230,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -158,6 +254,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -176,6 +303,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {
@@ -252,15 +383,6 @@ func (r *AlbumsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Albums", columns, values
-}
-
-func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *AlbumsRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -285,6 +407,34 @@ func (r *AlbumsRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
+	return "Albums", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.AlbumId,
+		r.AlbumTitle,
+	}
+}
+
+func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "AlbumId":
+			values = append(values, r.AlbumId)
+		case "AlbumTitle":
+			values = append(values, r.AlbumTitle)
+		default:
+			panic(fmt.Errorf("table Albums does not have column %s", column))
+		}
+	}
+	return "Albums", columns, values
+}
+
 func (r *AlbumsRow) PrimaryKey() AlbumsPrimaryKey {
 	return AlbumsPrimaryKey{
 		SingerId: r.SingerId,
@@ -306,6 +456,10 @@ func (k AlbumsPrimaryKey) SpannerKey() spanner.Key {
 
 func (k AlbumsPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k AlbumsPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
 }
 
 func (k AlbumsPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/2.sql.interleavedrowiterator.go
+++ b/internal/codegen/tablecodegen/testdata/2.sql.interleavedrowiterator.go
@@ -46,8 +46,14 @@ type SingersAndAlbumsRow struct {
 	Albums     []*AlbumsRow       `spanner:"Albums"`
 }
 
-func (r *SingersAndAlbumsRow) PrimaryKey() SingersPrimaryKey {
+func (r *SingersAndAlbumsRow) SingersPrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
+		SingerId: r.SingerId,
+	}
+}
+
+func (r SingersAndAlbumsRow) AlbumsPartialKey() AlbumsPartialKey {
+	return AlbumsPartialKey{
 		SingerId: r.SingerId,
 	}
 }
@@ -80,6 +86,105 @@ func (r *SingersAndAlbumsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 		}
 	}
 	return nil
+}
+
+func (r SingersAndAlbumsRow) SingersRow() *SingersRow {
+	return &SingersRow{
+		SingerId:   r.SingerId,
+		FirstName:  r.FirstName,
+		LastName:   r.LastName,
+		SingerInfo: r.SingerInfo,
+	}
+}
+
+func (r SingersAndAlbumsRow) Insert() []*spanner.Mutation {
+	n := 1
+	n += len(r.Albums)
+	mutations := make([]*spanner.Mutation, 0, n)
+	mutations = append(mutations, r.SingersRow().Insert())
+	for _, interleavedRow := range r.Albums {
+		mutations = append(mutations, interleavedRow.Insert())
+	}
+	return mutations
+}
+
+func (r SingersAndAlbumsRow) Update() []*spanner.Mutation {
+	n := 2 // one delete mutation per interleaved table
+	n += len(r.Albums)
+	mutations := make([]*spanner.Mutation, 0, n)
+	mutations = append(mutations, r.SingersRow().Update())
+	mutations = append(mutations, r.AlbumsPartialKey().Delete())
+	for _, interleavedRow := range r.Albums {
+		mutations = append(mutations, interleavedRow.Insert())
+	}
+	return mutations
+}
+
+type AlbumsPartialKey struct {
+	SingerId     int64
+	AlbumId      int64
+	ValidAlbumId bool
+}
+
+func (k AlbumsPartialKey) SpannerKey() spanner.Key {
+	n := 1
+	if k.ValidAlbumId {
+		n++
+	}
+	result := make(spanner.Key, 0, n)
+	result = append(result, k.SingerId)
+	if k.ValidAlbumId {
+		result = append(result, k.AlbumId)
+	}
+	return result
+}
+
+func (k AlbumsPartialKey) SpannerKeySet() spanner.KeySet {
+	return k.SpannerKey()
+}
+
+func (k AlbumsPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
+}
+
+func (k AlbumsPartialKey) BoolExpr() spansql.BoolExpr {
+	b := spansql.BoolExpr(spansql.ComparisonOp{
+		Op:  spansql.Eq,
+		LHS: spansql.ID("SingerId"),
+		RHS: spansql.IntegerLiteral(k.SingerId),
+	})
+	if k.ValidAlbumId {
+		b = spansql.LogicalOp{
+			Op:  spansql.And,
+			LHS: b,
+			RHS: spansql.ComparisonOp{
+				Op:  spansql.Eq,
+				LHS: spansql.ID("AlbumId"),
+				RHS: spansql.IntegerLiteral(k.AlbumId),
+			},
+		}
+	}
+	return spansql.Paren{Expr: b}
+}
+
+func (k AlbumsPartialKey) QualifiedBoolExpr(prefix spansql.PathExp) spansql.BoolExpr {
+	b := spansql.BoolExpr(spansql.ComparisonOp{
+		Op:  spansql.Eq,
+		LHS: append(prefix, spansql.ID("SingerId")),
+		RHS: spansql.IntegerLiteral(k.SingerId),
+	})
+	if k.ValidAlbumId {
+		b = spansql.LogicalOp{
+			Op:  spansql.And,
+			LHS: b,
+			RHS: spansql.ComparisonOp{
+				Op:  spansql.Eq,
+				LHS: append(prefix, spansql.ID("AlbumId")),
+				RHS: spansql.IntegerLiteral(k.AlbumId),
+			},
+		}
+	}
+	return spansql.Paren{Expr: b}
 }
 
 type SingersRow struct {
@@ -152,15 +257,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -185,6 +281,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -203,6 +330,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {
@@ -279,15 +410,6 @@ func (r *AlbumsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Albums", columns, values
-}
-
-func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *AlbumsRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -312,6 +434,34 @@ func (r *AlbumsRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
+	return "Albums", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.AlbumId,
+		r.AlbumTitle,
+	}
+}
+
+func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "AlbumId":
+			values = append(values, r.AlbumId)
+		case "AlbumTitle":
+			values = append(values, r.AlbumTitle)
+		default:
+			panic(fmt.Errorf("table Albums does not have column %s", column))
+		}
+	}
+	return "Albums", columns, values
+}
+
 func (r *AlbumsRow) PrimaryKey() AlbumsPrimaryKey {
 	return AlbumsPrimaryKey{
 		SingerId: r.SingerId,
@@ -333,6 +483,10 @@ func (k AlbumsPrimaryKey) SpannerKey() spanner.Key {
 
 func (k AlbumsPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k AlbumsPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
 }
 
 func (k AlbumsPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/2.sql.keyrange.go
+++ b/internal/codegen/tablecodegen/testdata/2.sql.keyrange.go
@@ -31,6 +31,10 @@ func (k SingersPartialKey) SpannerKey() spanner.Key {
 	return spanner.Key{k.SingerId}
 }
 
+func (k SingersPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
+}
+
 func (k SingersPartialKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
@@ -84,6 +88,10 @@ func (k AlbumsPartialKey) SpannerKey() spanner.Key {
 
 func (k AlbumsPartialKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k AlbumsPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
 }
 
 func (k AlbumsPartialKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/2.sql.partialkey.go
+++ b/internal/codegen/tablecodegen/testdata/2.sql.partialkey.go
@@ -17,6 +17,10 @@ func (k SingersPartialKey) SpannerKey() spanner.Key {
 	return spanner.Key{k.SingerId}
 }
 
+func (k SingersPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
+}
+
 func (k SingersPartialKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
@@ -56,6 +60,10 @@ func (k AlbumsPartialKey) SpannerKey() spanner.Key {
 
 func (k AlbumsPartialKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k AlbumsPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
 }
 
 func (k AlbumsPartialKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/2.sql.primarykey.go
+++ b/internal/codegen/tablecodegen/testdata/2.sql.primarykey.go
@@ -23,6 +23,10 @@ func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
 }
 
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
+}
+
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
@@ -55,6 +59,10 @@ func (k AlbumsPrimaryKey) SpannerKey() spanner.Key {
 
 func (k AlbumsPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k AlbumsPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
 }
 
 func (k AlbumsPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/2.sql.readtransaction.go
+++ b/internal/codegen/tablecodegen/testdata/2.sql.readtransaction.go
@@ -207,15 +207,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -240,6 +231,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -258,6 +280,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {
@@ -457,15 +483,6 @@ func (r *AlbumsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Albums", columns, values
-}
-
-func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *AlbumsRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -490,6 +507,34 @@ func (r *AlbumsRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
+	return "Albums", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.AlbumId,
+		r.AlbumTitle,
+	}
+}
+
+func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "AlbumId":
+			values = append(values, r.AlbumId)
+		case "AlbumTitle":
+			values = append(values, r.AlbumTitle)
+		default:
+			panic(fmt.Errorf("table Albums does not have column %s", column))
+		}
+	}
+	return "Albums", columns, values
+}
+
 func (r *AlbumsRow) PrimaryKey() AlbumsPrimaryKey {
 	return AlbumsPrimaryKey{
 		SingerId: r.SingerId,
@@ -511,6 +556,10 @@ func (k AlbumsPrimaryKey) SpannerKey() spanner.Key {
 
 func (k AlbumsPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k AlbumsPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
 }
 
 func (k AlbumsPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/2.sql.row.go
+++ b/internal/codegen/tablecodegen/testdata/2.sql.row.go
@@ -81,15 +81,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -114,6 +105,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -132,6 +154,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {
@@ -208,15 +234,6 @@ func (r *AlbumsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Albums", columns, values
-}
-
-func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *AlbumsRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -241,6 +258,34 @@ func (r *AlbumsRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
+	return "Albums", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.AlbumId,
+		r.AlbumTitle,
+	}
+}
+
+func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "AlbumId":
+			values = append(values, r.AlbumId)
+		case "AlbumTitle":
+			values = append(values, r.AlbumTitle)
+		default:
+			panic(fmt.Errorf("table Albums does not have column %s", column))
+		}
+	}
+	return "Albums", columns, values
+}
+
 func (r *AlbumsRow) PrimaryKey() AlbumsPrimaryKey {
 	return AlbumsPrimaryKey{
 		SingerId: r.SingerId,
@@ -262,6 +307,10 @@ func (k AlbumsPrimaryKey) SpannerKey() spanner.Key {
 
 func (k AlbumsPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k AlbumsPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
 }
 
 func (k AlbumsPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/codegen/tablecodegen/testdata/2.sql.rowiterator.go
+++ b/internal/codegen/tablecodegen/testdata/2.sql.rowiterator.go
@@ -107,15 +107,6 @@ func (r *SingersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Singers", columns, values
-}
-
-func (r *SingersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SingersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -140,6 +131,37 @@ func (r *SingersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *SingersRow) Mutation() (string, []string, []interface{}) {
+	return "Singers", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.FirstName,
+		r.LastName,
+		r.SingerInfo,
+	}
+}
+
+func (r *SingersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "FirstName":
+			values = append(values, r.FirstName)
+		case "LastName":
+			values = append(values, r.LastName)
+		case "SingerInfo":
+			values = append(values, r.SingerInfo)
+		default:
+			panic(fmt.Errorf("table Singers does not have column %s", column))
+		}
+	}
+	return "Singers", columns, values
+}
+
 func (r *SingersRow) PrimaryKey() SingersPrimaryKey {
 	return SingersPrimaryKey{
 		SingerId: r.SingerId,
@@ -158,6 +180,10 @@ func (k SingersPrimaryKey) SpannerKey() spanner.Key {
 
 func (k SingersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SingersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Singers", k.SpannerKey())
 }
 
 func (k SingersPrimaryKey) BoolExpr() spansql.BoolExpr {
@@ -260,15 +286,6 @@ func (r *AlbumsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "Albums", columns, values
-}
-
-func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *AlbumsRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -293,6 +310,34 @@ func (r *AlbumsRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
 }
 
+func (r *AlbumsRow) Mutation() (string, []string, []interface{}) {
+	return "Albums", r.ColumnNames(), []interface{}{
+		r.SingerId,
+		r.AlbumId,
+		r.AlbumTitle,
+	}
+}
+
+func (r *AlbumsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "SingerId":
+			values = append(values, r.SingerId)
+		case "AlbumId":
+			values = append(values, r.AlbumId)
+		case "AlbumTitle":
+			values = append(values, r.AlbumTitle)
+		default:
+			panic(fmt.Errorf("table Albums does not have column %s", column))
+		}
+	}
+	return "Albums", columns, values
+}
+
 func (r *AlbumsRow) PrimaryKey() AlbumsPrimaryKey {
 	return AlbumsPrimaryKey{
 		SingerId: r.SingerId,
@@ -314,6 +359,10 @@ func (k AlbumsPrimaryKey) SpannerKey() spanner.Key {
 
 func (k AlbumsPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k AlbumsPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("Albums", k.SpannerKey())
 }
 
 func (k AlbumsPrimaryKey) BoolExpr() spansql.BoolExpr {

--- a/internal/examples/freightdb/tables_gen.go
+++ b/internal/examples/freightdb/tables_gen.go
@@ -152,6 +152,10 @@ func (k ShippersPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
 }
 
+func (k ShippersPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("shippers", k.SpannerKey())
+}
+
 func (k ShippersPrimaryKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
@@ -176,6 +180,10 @@ type ShippersPartialKey struct {
 
 func (k ShippersPartialKey) SpannerKey() spanner.Key {
 	return spanner.Key{k.ShipperId}
+}
+
+func (k ShippersPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("shippers", k.SpannerKey())
 }
 
 func (k ShippersPartialKey) BoolExpr() spansql.BoolExpr {
@@ -277,15 +285,6 @@ func (r *ShippersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *ShippersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "shippers", columns, values
-}
-
-func (r *ShippersRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *ShippersRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -308,6 +307,37 @@ func (r *ShippersRow) InsertOrUpdateColumns(columns []string) *spanner.Mutation 
 
 func (r *ShippersRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
+}
+
+func (r *ShippersRow) Mutation() (string, []string, []interface{}) {
+	return "shippers", r.ColumnNames(), []interface{}{
+		r.ShipperId,
+		r.CreateTime,
+		r.UpdateTime,
+		r.DeleteTime,
+	}
+}
+
+func (r *ShippersRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "shipper_id":
+			values = append(values, r.ShipperId)
+		case "create_time":
+			values = append(values, r.CreateTime)
+		case "update_time":
+			values = append(values, r.UpdateTime)
+		case "delete_time":
+			values = append(values, r.DeleteTime)
+		default:
+			panic(fmt.Errorf("table shippers does not have column %s", column))
+		}
+	}
+	return "shippers", columns, values
 }
 
 func (r *ShippersRow) PrimaryKey() ShippersPrimaryKey {
@@ -455,6 +485,10 @@ func (k SitesPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
 }
 
+func (k SitesPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("sites", k.SpannerKey())
+}
+
 func (k SitesPrimaryKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
@@ -512,6 +546,10 @@ func (k SitesPartialKey) SpannerKey() spanner.Key {
 
 func (k SitesPartialKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k SitesPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("sites", k.SpannerKey())
 }
 
 func (k SitesPartialKey) BoolExpr() spansql.BoolExpr {
@@ -673,15 +711,6 @@ func (r *SitesRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *SitesRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "sites", columns, values
-}
-
-func (r *SitesRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *SitesRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -704,6 +733,49 @@ func (r *SitesRow) InsertOrUpdateColumns(columns []string) *spanner.Mutation {
 
 func (r *SitesRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
+}
+
+func (r *SitesRow) Mutation() (string, []string, []interface{}) {
+	return "sites", r.ColumnNames(), []interface{}{
+		r.ShipperId,
+		r.SiteId,
+		r.CreateTime,
+		r.UpdateTime,
+		r.DeleteTime,
+		r.DisplayName,
+		r.Latitude,
+		r.Longitude,
+	}
+}
+
+func (r *SitesRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "shipper_id":
+			values = append(values, r.ShipperId)
+		case "site_id":
+			values = append(values, r.SiteId)
+		case "create_time":
+			values = append(values, r.CreateTime)
+		case "update_time":
+			values = append(values, r.UpdateTime)
+		case "delete_time":
+			values = append(values, r.DeleteTime)
+		case "display_name":
+			values = append(values, r.DisplayName)
+		case "latitude":
+			values = append(values, r.Latitude)
+		case "longitude":
+			values = append(values, r.Longitude)
+		default:
+			panic(fmt.Errorf("table sites does not have column %s", column))
+		}
+	}
+	return "sites", columns, values
 }
 
 func (r *SitesRow) PrimaryKey() SitesPrimaryKey {
@@ -852,6 +924,10 @@ func (k ShipmentsPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
 }
 
+func (k ShipmentsPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("shipments", k.SpannerKey())
+}
+
 func (k ShipmentsPrimaryKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
@@ -909,6 +985,10 @@ func (k ShipmentsPartialKey) SpannerKey() spanner.Key {
 
 func (k ShipmentsPartialKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k ShipmentsPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("shipments", k.SpannerKey())
 }
 
 func (k ShipmentsPartialKey) BoolExpr() spansql.BoolExpr {
@@ -1097,15 +1177,6 @@ func (r *ShipmentsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *ShipmentsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "shipments", columns, values
-}
-
-func (r *ShipmentsRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *ShipmentsRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -1128,6 +1199,58 @@ func (r *ShipmentsRow) InsertOrUpdateColumns(columns []string) *spanner.Mutation
 
 func (r *ShipmentsRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
+}
+
+func (r *ShipmentsRow) Mutation() (string, []string, []interface{}) {
+	return "shipments", r.ColumnNames(), []interface{}{
+		r.ShipperId,
+		r.ShipmentId,
+		r.CreateTime,
+		r.UpdateTime,
+		r.DeleteTime,
+		r.OriginSiteId,
+		r.DestinationSiteId,
+		r.PickupEarliestTime,
+		r.PickupLatestTime,
+		r.DeliveryEarliestTime,
+		r.DeliveryLatestTime,
+	}
+}
+
+func (r *ShipmentsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "shipper_id":
+			values = append(values, r.ShipperId)
+		case "shipment_id":
+			values = append(values, r.ShipmentId)
+		case "create_time":
+			values = append(values, r.CreateTime)
+		case "update_time":
+			values = append(values, r.UpdateTime)
+		case "delete_time":
+			values = append(values, r.DeleteTime)
+		case "origin_site_id":
+			values = append(values, r.OriginSiteId)
+		case "destination_site_id":
+			values = append(values, r.DestinationSiteId)
+		case "pickup_earliest_time":
+			values = append(values, r.PickupEarliestTime)
+		case "pickup_latest_time":
+			values = append(values, r.PickupLatestTime)
+		case "delivery_earliest_time":
+			values = append(values, r.DeliveryEarliestTime)
+		case "delivery_latest_time":
+			values = append(values, r.DeliveryLatestTime)
+		default:
+			panic(fmt.Errorf("table shipments does not have column %s", column))
+		}
+	}
+	return "shipments", columns, values
 }
 
 func (r *ShipmentsRow) PrimaryKey() ShipmentsPrimaryKey {
@@ -1247,7 +1370,7 @@ func (t ShipmentsAndLineItemsReadTransaction) BatchGet(
 	defer it.Stop()
 	foundRows := make(map[ShipmentsPrimaryKey]*ShipmentsAndLineItemsRow, len(keys))
 	if err := it.Do(func(row *ShipmentsAndLineItemsRow) error {
-		foundRows[row.PrimaryKey()] = row
+		foundRows[row.ShipmentsPrimaryKey()] = row
 		return nil
 	}); err != nil {
 		return nil, err
@@ -1304,10 +1427,18 @@ type ShipmentsAndLineItemsRow struct {
 	LineItems            []*LineItemsRow    `spanner:"line_items"`
 }
 
-func (r *ShipmentsAndLineItemsRow) PrimaryKey() ShipmentsPrimaryKey {
+func (r *ShipmentsAndLineItemsRow) ShipmentsPrimaryKey() ShipmentsPrimaryKey {
 	return ShipmentsPrimaryKey{
 		ShipperId:  r.ShipperId,
 		ShipmentId: r.ShipmentId,
+	}
+}
+
+func (r ShipmentsAndLineItemsRow) LineItemsPartialKey() LineItemsPartialKey {
+	return LineItemsPartialKey{
+		ShipperId:       r.ShipperId,
+		ShipmentId:      r.ShipmentId,
+		ValidShipmentId: true,
 	}
 }
 
@@ -1367,6 +1498,45 @@ func (r *ShipmentsAndLineItemsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 		}
 	}
 	return nil
+}
+
+func (r ShipmentsAndLineItemsRow) ShipmentsRow() *ShipmentsRow {
+	return &ShipmentsRow{
+		ShipperId:            r.ShipperId,
+		ShipmentId:           r.ShipmentId,
+		CreateTime:           r.CreateTime,
+		UpdateTime:           r.UpdateTime,
+		DeleteTime:           r.DeleteTime,
+		OriginSiteId:         r.OriginSiteId,
+		DestinationSiteId:    r.DestinationSiteId,
+		PickupEarliestTime:   r.PickupEarliestTime,
+		PickupLatestTime:     r.PickupLatestTime,
+		DeliveryEarliestTime: r.DeliveryEarliestTime,
+		DeliveryLatestTime:   r.DeliveryLatestTime,
+	}
+}
+
+func (r ShipmentsAndLineItemsRow) Insert() []*spanner.Mutation {
+	n := 1
+	n += len(r.LineItems)
+	mutations := make([]*spanner.Mutation, 0, n)
+	mutations = append(mutations, r.ShipmentsRow().Insert())
+	for _, interleavedRow := range r.LineItems {
+		mutations = append(mutations, interleavedRow.Insert())
+	}
+	return mutations
+}
+
+func (r ShipmentsAndLineItemsRow) Update() []*spanner.Mutation {
+	n := 2 // one delete mutation per interleaved table
+	n += len(r.LineItems)
+	mutations := make([]*spanner.Mutation, 0, n)
+	mutations = append(mutations, r.ShipmentsRow().Update())
+	mutations = append(mutations, r.LineItemsPartialKey().Delete())
+	for _, interleavedRow := range r.LineItems {
+		mutations = append(mutations, interleavedRow.Insert())
+	}
+	return mutations
 }
 
 type LineItemsReadTransaction struct {
@@ -1510,6 +1680,10 @@ func (k LineItemsPrimaryKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
 }
 
+func (k LineItemsPrimaryKey) Delete() *spanner.Mutation {
+	return spanner.Delete("line_items", k.SpannerKey())
+}
+
 func (k LineItemsPrimaryKey) BoolExpr() spansql.BoolExpr {
 	b := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
@@ -1593,6 +1767,10 @@ func (k LineItemsPartialKey) SpannerKey() spanner.Key {
 
 func (k LineItemsPartialKey) SpannerKeySet() spanner.KeySet {
 	return k.SpannerKey()
+}
+
+func (k LineItemsPartialKey) Delete() *spanner.Mutation {
+	return spanner.Delete("line_items", k.SpannerKey())
 }
 
 func (k LineItemsPartialKey) BoolExpr() spansql.BoolExpr {
@@ -1768,15 +1946,6 @@ func (r *LineItemsRow) UnmarshalSpannerRow(row *spanner.Row) error {
 	return nil
 }
 
-func (r *LineItemsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
-	var values []interface{}
-	return "line_items", columns, values
-}
-
-func (r *LineItemsRow) Mutation() (string, []string, []interface{}) {
-	return r.MutationForColumns(r.ColumnNames())
-}
-
 func (r *LineItemsRow) Insert() *spanner.Mutation {
 	return spanner.Insert(r.Mutation())
 }
@@ -1799,6 +1968,46 @@ func (r *LineItemsRow) InsertOrUpdateColumns(columns []string) *spanner.Mutation
 
 func (r *LineItemsRow) UpdateColumns(columns []string) *spanner.Mutation {
 	return spanner.Update(r.MutationForColumns(columns))
+}
+
+func (r *LineItemsRow) Mutation() (string, []string, []interface{}) {
+	return "line_items", r.ColumnNames(), []interface{}{
+		r.ShipperId,
+		r.ShipmentId,
+		r.LineNumber,
+		r.Title,
+		r.Quantity,
+		r.WeightKg,
+		r.VolumeM3,
+	}
+}
+
+func (r *LineItemsRow) MutationForColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "shipper_id":
+			values = append(values, r.ShipperId)
+		case "shipment_id":
+			values = append(values, r.ShipmentId)
+		case "line_number":
+			values = append(values, r.LineNumber)
+		case "title":
+			values = append(values, r.Title)
+		case "quantity":
+			values = append(values, r.Quantity)
+		case "weight_kg":
+			values = append(values, r.WeightKg)
+		case "volume_m3":
+			values = append(values, r.VolumeM3)
+		default:
+			panic(fmt.Errorf("table line_items does not have column %s", column))
+		}
+	}
+	return "line_items", columns, values
 }
 
 func (r *LineItemsRow) PrimaryKey() LineItemsPrimaryKey {


### PR DESCRIPTION
All types of mutations for basic rows.

Insert, Update and InsertOrUpdate for interleaved rows.

Delete mutation for interleaved rows will use a specific key type for
interleaved rows that can generate a primary key delete for the
top-level table and key prefix deletes for interleaved tables.
