### PR TITLE
feat: add InterleavedTables field to spanddl.Table

### DIFF
--- a/internal/codegen/databasecodegen/database.go
+++ b/internal/codegen/databasecodegen/database.go
@@ -15,21 +15,17 @@ func (g DatabaseCodeGenerator) GenerateCode(f *codegen.File) {
 		RowIteratorCodeGenerator{Table: table}.GenerateCode(f)
 		KeyCodeGenerator{Table: table}.GenerateCode(f)
 		RowCodeGenerator{Table: table}.GenerateCode(f)
-		interleavedTables := g.Database.InterleavedTables(table.Name)
-		if len(interleavedTables) == 0 {
+		if len(table.InterleavedTables) == 0 {
 			continue
 		}
 		InterleavedReadTransactionCodeGenerator{
-			Table:             table,
-			InterleavedTables: interleavedTables,
+			Table: table,
 		}.GenerateCode(f)
 		InterleavedRowIteratorCodeGenerator{
-			Table:             table,
-			InterleavedTables: interleavedTables,
+			Table: table,
 		}.GenerateCode(f)
 		InterleavedRowCodeGenerator{
-			Table:             table,
-			InterleavedTables: interleavedTables,
+			Table: table,
 		}.GenerateCode(f)
 	}
 	CommonCodeGenerator{}.GenerateCode(f)

--- a/internal/codegen/databasecodegen/interleavedreadtransaction.go
+++ b/internal/codegen/databasecodegen/interleavedreadtransaction.go
@@ -8,8 +8,7 @@ import (
 )
 
 type InterleavedReadTransactionCodeGenerator struct {
-	Table             *spanddl.Table
-	InterleavedTables []*spanddl.Table
+	Table *spanddl.Table
 }
 
 func (g InterleavedReadTransactionCodeGenerator) Type() string {
@@ -50,7 +49,7 @@ func (g InterleavedReadTransactionCodeGenerator) generateListRowsMethod(f *codeg
 		offsetParam = "offset"
 	)
 	rowIterator := InterleavedRowIteratorCodeGenerator(g)
-	key := KeyCodeGenerator{Table: g.Table}
+	key := KeyCodeGenerator(g)
 	contextPkg := f.Import("context")
 	stringsPkg := f.Import("strings")
 	spannerPkg := f.Import("cloud.google.com/go/spanner")
@@ -67,7 +66,7 @@ func (g InterleavedReadTransactionCodeGenerator) generateListRowsMethod(f *codeg
 	for _, column := range g.Table.Columns {
 		f.P(`_, _ = q.WriteString("`, column.Name, `, ")`)
 	}
-	for _, interleavedTable := range g.InterleavedTables {
+	for _, interleavedTable := range g.Table.InterleavedTables {
 		f.P(`_, _ = q.WriteString("ARRAY( ")`)
 		f.P(`_, _ = q.WriteString("SELECT AS STRUCT ")`)
 		for _, column := range interleavedTable.Columns {
@@ -128,7 +127,7 @@ func (g InterleavedReadTransactionCodeGenerator) generateListRowsMethod(f *codeg
 }
 
 func (g InterleavedReadTransactionCodeGenerator) generateGetRowMethod(f *codegen.File) {
-	primaryKey := KeyCodeGenerator{Table: g.Table}
+	primaryKey := KeyCodeGenerator(g)
 	row := InterleavedRowCodeGenerator(g)
 	common := CommonCodeGenerator{}
 	contextPkg := f.Import("context")
@@ -157,7 +156,7 @@ func (g InterleavedReadTransactionCodeGenerator) generateGetRowMethod(f *codegen
 }
 
 func (g InterleavedReadTransactionCodeGenerator) generateBatchGetRowsMethod(f *codegen.File) {
-	primaryKey := KeyCodeGenerator{Table: g.Table}
+	primaryKey := KeyCodeGenerator(g)
 	interleavedRow := InterleavedRowCodeGenerator(g)
 	common := CommonCodeGenerator{}
 	contextPkg := f.Import("context")

--- a/internal/codegen/databasecodegen/interleavedrow.go
+++ b/internal/codegen/databasecodegen/interleavedrow.go
@@ -12,14 +12,13 @@ import (
 )
 
 type InterleavedRowCodeGenerator struct {
-	Table             *spanddl.Table
-	InterleavedTables []*spanddl.Table
+	Table *spanddl.Table
 }
 
 func (g InterleavedRowCodeGenerator) Ident() string {
 	var t strings.Builder
 	_, _ = t.WriteString(strcase.UpperCamelCase(string(g.Table.Name)))
-	for _, interleavedTable := range g.InterleavedTables {
+	for _, interleavedTable := range g.Table.InterleavedTables {
 		_, _ = t.WriteString("And")
 		_, _ = t.WriteString(strcase.UpperCamelCase(string(interleavedTable.Name)))
 	}
@@ -43,13 +42,13 @@ func (g InterleavedRowCodeGenerator) InterleavedRowsField(table *spanddl.Table) 
 }
 
 func (g InterleavedRowCodeGenerator) GenerateCode(f *codegen.File) {
-	row := RowCodeGenerator{Table: g.Table}
+	row := RowCodeGenerator(g)
 	f.P()
 	f.P("type ", g.Type(), " struct {")
 	for _, column := range g.Table.Columns {
 		row.generateColumn(f, column)
 	}
-	for _, interleavedTable := range g.InterleavedTables {
+	for _, interleavedTable := range g.Table.InterleavedTables {
 		interleavedRow := RowCodeGenerator{Table: interleavedTable}
 		f.P(
 			g.InterleavedRowsField(interleavedTable), " []*", interleavedRow.Type(),
@@ -66,16 +65,16 @@ func (g InterleavedRowCodeGenerator) GenerateCode(f *codegen.File) {
 
 func (g InterleavedRowCodeGenerator) generateInsertMutationMethod(f *codegen.File) {
 	spannerPkg := f.Import("cloud.google.com/go/spanner")
-	row := RowCodeGenerator{Table: g.Table}
+	row := RowCodeGenerator(g)
 	f.P()
 	f.P("func (r ", g.Type(), ") Insert() []*", spannerPkg, ".Mutation {")
 	f.P("n := 1")
-	for _, interleavedTable := range g.InterleavedTables {
+	for _, interleavedTable := range g.Table.InterleavedTables {
 		f.P("n+=len(r.", g.InterleavedRowsField(interleavedTable), ")")
 	}
 	f.P("mutations := make([]*", spannerPkg, ".Mutation, 0, n)")
 	f.P("mutations = append(mutations, r.", row.Type(), "().Insert())")
-	for _, interleavedTable := range g.InterleavedTables {
+	for _, interleavedTable := range g.Table.InterleavedTables {
 		f.P("for _, interleavedRow := range r.", g.InterleavedRowsField(interleavedTable), " {")
 		f.P("mutations = append(mutations, interleavedRow.Insert())")
 		f.P("}")
@@ -86,16 +85,16 @@ func (g InterleavedRowCodeGenerator) generateInsertMutationMethod(f *codegen.Fil
 
 func (g InterleavedRowCodeGenerator) generateUpdateMutationMethod(f *codegen.File) {
 	spannerPkg := f.Import("cloud.google.com/go/spanner")
-	row := RowCodeGenerator{Table: g.Table}
+	row := RowCodeGenerator(g)
 	f.P()
 	f.P("func (r ", g.Type(), ") Update() []*", spannerPkg, ".Mutation {")
-	f.P("n := ", 1+len(g.InterleavedTables), " // one delete mutation per interleaved table")
-	for _, interleavedTable := range g.InterleavedTables {
+	f.P("n := ", 1+len(g.Table.InterleavedTables), " // one delete mutation per interleaved table")
+	for _, interleavedTable := range g.Table.InterleavedTables {
 		f.P("n+=len(r.", g.InterleavedRowsField(interleavedTable), ")")
 	}
 	f.P("mutations := make([]*", spannerPkg, ".Mutation, 0, n)")
 	f.P("mutations = append(mutations, r.", row.Type(), "().Update())")
-	for _, interleavedTable := range g.InterleavedTables {
+	for _, interleavedTable := range g.Table.InterleavedTables {
 		f.P(
 			"mutations = append(mutations, ",
 			spannerPkg,
@@ -112,7 +111,7 @@ func (g InterleavedRowCodeGenerator) generateUpdateMutationMethod(f *codegen.Fil
 }
 
 func (g InterleavedRowCodeGenerator) generateRowMethod(f *codegen.File) {
-	row := RowCodeGenerator{Table: g.Table}
+	row := RowCodeGenerator(g)
 	f.P()
 	f.P("func (r ", g.Type(), ") ", row.Type(), "() *", row.Type(), " {")
 	f.P("return &", row.Type(), "{")
@@ -124,7 +123,7 @@ func (g InterleavedRowCodeGenerator) generateRowMethod(f *codegen.File) {
 }
 
 func (g InterleavedRowCodeGenerator) generateUnmarshalFunction(f *codegen.File) {
-	row := RowCodeGenerator{Table: g.Table}
+	row := RowCodeGenerator(g)
 	fmtPkg := f.Import("fmt")
 	spannerPkg := f.Import("cloud.google.com/go/spanner")
 	f.P()
@@ -137,7 +136,7 @@ func (g InterleavedRowCodeGenerator) generateUnmarshalFunction(f *codegen.File) 
 		f.P(`return `, fmtPkg, `.Errorf("unmarshal `, g.Table.Name, ` row: `, column.Name, ` column: %w", err)`)
 		f.P("}")
 	}
-	for _, interleavedTable := range g.InterleavedTables {
+	for _, interleavedTable := range g.Table.InterleavedTables {
 		f.P("case ", strconv.Quote(string(interleavedTable.Name)), ":")
 		f.P("if err := row.Column(i, &r.", g.InterleavedRowsField(interleavedTable), "); err != nil {")
 		f.P(
@@ -155,8 +154,8 @@ func (g InterleavedRowCodeGenerator) generateUnmarshalFunction(f *codegen.File) 
 }
 
 func (g InterleavedRowCodeGenerator) generateKeyMethod(f *codegen.File) {
-	primaryKey := KeyCodeGenerator{g.Table}
-	row := RowCodeGenerator{Table: g.Table}
+	primaryKey := KeyCodeGenerator(g)
+	row := RowCodeGenerator(g)
 	f.P()
 	f.P("func (r *", g.Type(), ") ", g.KeyMethod(), "() ", primaryKey.Type(), " {")
 	f.P("return ", primaryKey.Type(), "{")

--- a/internal/codegen/databasecodegen/interleavedrowiterator.go
+++ b/internal/codegen/databasecodegen/interleavedrowiterator.go
@@ -6,8 +6,7 @@ import (
 )
 
 type InterleavedRowIteratorCodeGenerator struct {
-	Table             *spanddl.Table
-	InterleavedTables []*spanddl.Table
+	Table *spanddl.Table
 }
 
 func (g InterleavedRowIteratorCodeGenerator) Type() string {

--- a/spanddl/database_test.go
+++ b/spanddl/database_test.go
@@ -134,6 +134,24 @@ func TestDatabase_ApplyDDL(t *testing.T) {
 						PrimaryKey: []spansql.KeyPart{
 							{Column: "SingerId"},
 						},
+						InterleavedTables: []*Table{
+							{
+								Name: "Albums",
+								Columns: []*Column{
+									{Name: "SingerId", Type: spansql.Type{Base: spansql.Int64}, NotNull: true},
+									{Name: "AlbumId", Type: spansql.Type{Base: spansql.Int64}, NotNull: true},
+									{Name: "AlbumTitle", Type: spansql.Type{Base: spansql.String, Len: spansql.MaxLen}},
+								},
+								PrimaryKey: []spansql.KeyPart{
+									{Column: "SingerId"},
+									{Column: "AlbumId"},
+								},
+								Interleave: &spansql.Interleave{
+									Parent:   "Singers",
+									OnDelete: spansql.CascadeOnDelete,
+								},
+							},
+						},
 					},
 
 					{

--- a/spanddl/table.go
+++ b/spanddl/table.go
@@ -8,10 +8,11 @@ import (
 
 // Table represents a Spanner table.
 type Table struct {
-	Name       spansql.ID
-	Columns    []*Column
-	PrimaryKey []spansql.KeyPart
-	Interleave *spansql.Interleave
+	Name              spansql.ID
+	Columns           []*Column
+	InterleavedTables []*Table
+	PrimaryKey        []spansql.KeyPart
+	Interleave        *spansql.Interleave
 }
 
 func (t *Table) applyAlterTable(stmt *spansql.AlterTable) error {


### PR DESCRIPTION
To aid code generation of multiple levels of interleaved tables.
Interleaved tables can be discovered by traversing the hierarchy from
the top-level table.
